### PR TITLE
fix stretch's cow build

### DIFF
--- a/hooks/G10-add-apt-key
+++ b/hooks/G10-add-apt-key
@@ -1,4 +1,5 @@
 #!/bin/bash
+apt-get install -y gnupg
 apt-key add -- <<EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1.4.10 (GNU/Linux)


### PR DESCRIPTION
DEFAULT_DISTS="wheezy jessie stretch"

`dr create` will failed to build stretch's cow env.